### PR TITLE
Update centos7 for OpenNebula

### DIFF
--- a/OpenNebula/centos/centos7.json
+++ b/OpenNebula/centos/centos7.json
@@ -3,7 +3,7 @@
   "name": "centos7.qcow2",
   "vm_name": "centos7",
   "kickstart": "centos7.cfg",
-  "iso_checksum": "937bf0a7b0932817f84f7230f15ed88911bbbd85c0c958680792b7f8d8f9c1a9",
+  "iso_checksum": "19d94274ef856c4dfcacb2e7cfe4be73e442a71dd65cc3fb6e46db826040b56e",
   "iso_checksum_type": "sha256",
-  "iso_url": "http://mirror.chpc.utah.edu/pub/centos/7/isos/x86_64/CentOS-7-x86_64-NetInstall-1804.iso"
+  "iso_url": "http://mirror.chpc.utah.edu/pub/centos/7/isos/x86_64/CentOS-7-x86_64-NetInstall-1810.iso"
 }

--- a/OpenNebula/centos/kickstart/centos7.cfg
+++ b/OpenNebula/centos/kickstart/centos7.cfg
@@ -17,7 +17,6 @@
 lang en_US.UTF-8
 keyboard us
 rootpw salt
-authconfig --enableshadow --enablemd5
 timezone UTC
 
 # Optional settings


### PR DESCRIPTION
Remove md5 passwords and use the default sha512 ones. Update to Centos 7.6.