### PR TITLE
change to m4.large for debian-8

### DIFF
--- a/AWS/debian/debian-8-us-west-2.json
+++ b/AWS/debian/debian-8-us-west-2.json
@@ -6,7 +6,7 @@
   "ami_owner": "679593333241",
   "ami_name_prefix": "saltstack",
   "ami_name_suffix": "debian/jessie.8",
-  "instance_type": "m5.large",
+  "instance_type": "m4.large",
   "build_type": "base",
   "device_name": "/dev/xvda",
   "os_name": "Debian",


### PR DESCRIPTION
apparently they haven't updated their marketplace settings to allow m5